### PR TITLE
Blue green

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Terraform module to create an ALB, default ALB listener(s), and a default ALB ta
 
 ---
 
-This project is part of our comprehensive ["SweetOps"](https://docs.cloudposse.com) approach towards DevOps. 
+This project is part of our comprehensive ["SweetOps"](https://docs.cloudposse.com) approach towards DevOps.
 
 
 It's 100% Open Source and licensed under the [APACHE2](LICENSE).
@@ -86,6 +86,13 @@ Available targets:
 | https_ingress_cidr_blocks | List of CIDR blocks to allow in HTTPS security group | list | `<list>` | no |
 | https_ingress_prefix_list_ids | List of prefix list IDs for allowing access to HTTPS ingress security group | list | `<list>` | no |
 | https_port | The port for the HTTPS listener | string | `443` | no |
+| blue_green_enabled | A boolean flag to enable/disable BLUE/Green target groups and production/test listeners | string | `false` | no |
+| prod_ingress_cidr_blocks | List of CIDR blocks to allow in production security group | list | `<list>` | no |
+| prod_ingress_prefix_list_ids | List of prefix list IDs for allowing access to production ingress security group | list | `<list>` | no |
+| prod_port | The port for the production listener | string | `80` | no |
+| test_ingress_cidr_blocks | List of CIDR blocks to allow in test security group | list | `<list>` | no |
+| test_ingress_prefix_list_ids | List of prefix list IDs for allowing access to test ingress security group | list | `<list>` | no |
+| test_port | The port for the test listener | string | `8080` | no |
 | idle_timeout | The time in seconds that the connection is allowed to be idle | string | `60` | no |
 | internal | A boolean flag to determine whether the ALB should be internal | string | `false` | no |
 | ip_address_type | The type of IP addresses used by the subnets for your load balancer. The possible values are `ipv4` and `dualstack`. | string | `ipv4` | no |
@@ -110,6 +117,8 @@ Available targets:
 | default_target_group_arn | The default target group ARN |
 | http_listener_arn | The ARN of the HTTP listener |
 | https_listener_arn | The ARN of the HTTPS listener |
+| prod_listener_arn | The ARN of the production listener in Blue/Green |
+| test_listener_arn | The ARN of the test listener in Blue/Green|
 | listener_arns | A list of all the listener ARNs |
 | security_group_id | The security group ID of the ALB |
 
@@ -132,9 +141,9 @@ File a GitHub [issue](https://github.com/cloudposse/terraform-aws-alb/issues), s
 
 ## Commercial Support
 
-Work directly with our team of DevOps experts via email, slack, and video conferencing. 
+Work directly with our team of DevOps experts via email, slack, and video conferencing.
 
-We provide [*commercial support*][commercial_support] for all of our [Open Source][github] projects. As a *Dedicated Support* customer, you have access to our team of subject matter experts at a fraction of the cost of a full-time engineer. 
+We provide [*commercial support*][commercial_support] for all of our [Open Source][github] projects. As a *Dedicated Support* customer, you have access to our team of subject matter experts at a fraction of the cost of a full-time engineer.
 
 [![E-Mail](https://img.shields.io/badge/email-hello@cloudposse.com-blue.svg)](mailto:hello@cloudposse.com)
 
@@ -144,7 +153,7 @@ We provide [*commercial support*][commercial_support] for all of our [Open Sourc
 - **Bug Fixes.** We'll rapidly work to fix any bugs in our projects.
 - **Build New Terraform Modules.** We'll develop original modules to provision infrastructure.
 - **Cloud Architecture.** We'll assist with your cloud strategy and design.
-- **Implementation.** We'll provide hands-on support to implement our reference architectures. 
+- **Implementation.** We'll provide hands-on support to implement our reference architectures.
 
 
 ## Community Forum
@@ -178,9 +187,9 @@ Copyright © 2017-2018 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 
-## License 
+## License
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 See [LICENSE](LICENSE) for full details.
 
@@ -221,7 +230,7 @@ This project is maintained and funded by [Cloud Posse, LLC][website]. Like it? P
 
 We're a [DevOps Professional Services][hire] company based in Los Angeles, CA. We love [Open Source Software](https://github.com/cloudposse/)!
 
-We offer paid support on all of our projects.  
+We offer paid support on all of our projects.
 
 Check out [our other projects][github], [apply for a job][jobs], or [hire us][hire] to help with your cloud strategy and implementation.
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Available targets:
 | access_logs_enabled | A boolean flag to enable/disable access_logs | string | `true` | no |
 | access_logs_prefix | The S3 bucket prefix | string | `` | no |
 | access_logs_region | The region for the access_logs S3 bucket | string | `us-east-1` | no |
+| access_logs_bucket_name | Bucket name (not recommended, legacy support only.) | string | `` | no |
 | attributes | Additional attributes, e.g. `1` | list | `<list>` | no |
 | certificate_arn | The ARN of the default SSL certificate for HTTPS listener | string | `` | no |
 | cross_zone_load_balancing_enabled | A boolean flag to enable/disable cross zone load balancing | string | `true` | no |

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Available targets:
 | alb_name | The ARN suffix of the ALB |
 | alb_zone_id | The ID of the zone which ALB is provisioned |
 | default_target_group_arn | The default target group ARN |
+| blue_target_group_arn | The blue target group ARN for Blue/Green |
+| green_target_group_arn | The green target group ARN for Blue/Green |
 | http_listener_arn | The ARN of the HTTP listener |
 | https_listener_arn | The ARN of the HTTPS listener |
 | prod_listener_arn | The ARN of the production listener in Blue/Green |

--- a/README.md
+++ b/README.md
@@ -116,12 +116,10 @@ Available targets:
 | alb_name | The ARN suffix of the ALB |
 | alb_zone_id | The ID of the zone which ALB is provisioned |
 | default_target_group_arn | The default target group ARN |
-| blue_target_group_arn | The blue target group ARN for Blue/Green |
-| green_target_group_arn | The green target group ARN for Blue/Green |
 | http_listener_arn | The ARN of the HTTP listener |
 | https_listener_arn | The ARN of the HTTPS listener |
 | prod_listener_arn | The ARN of the production listener in Blue/Green |
-| test_listener_arn | The ARN of the test listener in Blue/Green|
+| test_listener_arn | The ARN of the test listener in Blue/Green |
 | listener_arns | A list of all the listener ARNs |
 | security_group_id | The security group ID of the ALB |
 

--- a/bg.tf
+++ b/bg.tf
@@ -20,72 +20,6 @@ resource "aws_security_group_rule" "test_ingress" {
   security_group_id = "${aws_security_group.default.id}"
 }
 
-module "blue_target_group_label" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.1.6"
-  attributes = "${concat(var.attributes, list("blue"))}"
-  delimiter  = "${var.delimiter}"
-  name       = "${var.name}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  tags       = "${var.tags}"
-}
-
-module "green_target_group_label" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.1.6"
-  attributes = "${concat(var.attributes, list("green"))}"
-  delimiter  = "${var.delimiter}"
-  name       = "${var.name}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  tags       = "${var.tags}"
-}
-
-resource "aws_lb_target_group" "blue" {
-  count                = "${var.blue_green_enabled == "true" ? 1 : 0}"
-  name                 = "${module.blue_target_group_label.id}"
-  port                 = "80"
-  protocol             = "HTTP"
-  vpc_id               = "${var.vpc_id}"
-  target_type          = "ip"
-  deregistration_delay = "${var.deregistration_delay}"
-
-  health_check {
-    path                = "${var.health_check_path}"
-    timeout             = "${var.health_check_timeout}"
-    healthy_threshold   = "${var.health_check_healthy_threshold}"
-    unhealthy_threshold = "${var.health_check_unhealthy_threshold}"
-    interval            = "${var.health_check_interval}"
-    matcher             = "${var.health_check_matcher}"
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_lb_target_group" "green" {
-  count                = "${var.blue_green_enabled == "true" ? 1 : 0}"
-  name                 = "${module.green_target_group_label.id}"
-  port                 = "80"
-  protocol             = "HTTP"
-  vpc_id               = "${var.vpc_id}"
-  target_type          = "ip"
-  deregistration_delay = "${var.deregistration_delay}"
-
-  health_check {
-    path                = "${var.health_check_path}"
-    timeout             = "${var.health_check_timeout}"
-    healthy_threshold   = "${var.health_check_healthy_threshold}"
-    unhealthy_threshold = "${var.health_check_unhealthy_threshold}"
-    interval            = "${var.health_check_interval}"
-    matcher             = "${var.health_check_matcher}"
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
 resource "aws_lb_listener" "prod" {
   count             = "${var.blue_green_enabled == "true" ? 1 : 0}"
   load_balancer_arn = "${aws_lb.default.arn}"
@@ -94,7 +28,7 @@ resource "aws_lb_listener" "prod" {
   protocol        = "HTTP"
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.blue.arn}"
+    target_group_arn = "${aws_lb_target_group.default.arn}"
     type             = "forward"
   }
 }
@@ -107,7 +41,7 @@ resource "aws_lb_listener" "test" {
   protocol        = "HTTP"
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.green.arn}"
+    target_group_arn = "${aws_lb_target_group.default.arn}"
     type             = "forward"
   }
 }

--- a/bg.tf
+++ b/bg.tf
@@ -1,0 +1,113 @@
+resource "aws_security_group_rule" "prod_ingress" {
+  count             = "${var.blue_green_enabled == "true" ? 1 : 0}"
+  type              = "ingress"
+  from_port         = "${var.prod_port}"
+  to_port           = "${var.prod_port}"
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.prod_ingress_cidr_blocks}"]
+  prefix_list_ids   = ["${var.prod_ingress_prefix_list_ids}"]
+  security_group_id = "${aws_security_group.default.id}"
+}
+
+resource "aws_security_group_rule" "test_ingress" {
+  count             = "${var.blue_green_enabled == "true" ? 1 : 0}"
+  type              = "ingress"
+  from_port         = "${var.test_port}"
+  to_port           = "${var.test_port}"
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.test_ingress_cidr_blocks}"]
+  prefix_list_ids   = ["${var.test_ingress_prefix_list_ids}"]
+  security_group_id = "${aws_security_group.default.id}"
+}
+
+module "blue_target_group_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.1.6"
+  attributes = "${concat(var.attributes, list("blue"))}"
+  delimiter  = "${var.delimiter}"
+  name       = "${var.name}"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  tags       = "${var.tags}"
+}
+
+module "green_target_group_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.1.6"
+  attributes = "${concat(var.attributes, list("green"))}"
+  delimiter  = "${var.delimiter}"
+  name       = "${var.name}"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  tags       = "${var.tags}"
+}
+
+resource "aws_lb_target_group" "blue" {
+  count                = "${var.blue_green_enabled == "true" ? 1 : 0}"
+  name                 = "${module.blue_target_group_label.id}"
+  port                 = "80"
+  protocol             = "HTTP"
+  vpc_id               = "${var.vpc_id}"
+  target_type          = "ip"
+  deregistration_delay = "${var.deregistration_delay}"
+
+  health_check {
+    path                = "${var.health_check_path}"
+    timeout             = "${var.health_check_timeout}"
+    healthy_threshold   = "${var.health_check_healthy_threshold}"
+    unhealthy_threshold = "${var.health_check_unhealthy_threshold}"
+    interval            = "${var.health_check_interval}"
+    matcher             = "${var.health_check_matcher}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_lb_target_group" "green" {
+  count                = "${var.blue_green_enabled == "true" ? 1 : 0}"
+  name                 = "${module.green_target_group_label.id}"
+  port                 = "80"
+  protocol             = "HTTP"
+  vpc_id               = "${var.vpc_id}"
+  target_type          = "ip"
+  deregistration_delay = "${var.deregistration_delay}"
+
+  health_check {
+    path                = "${var.health_check_path}"
+    timeout             = "${var.health_check_timeout}"
+    healthy_threshold   = "${var.health_check_healthy_threshold}"
+    unhealthy_threshold = "${var.health_check_unhealthy_threshold}"
+    interval            = "${var.health_check_interval}"
+    matcher             = "${var.health_check_matcher}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_lb_listener" "prod" {
+  count             = "${var.blue_green_enabled == "true" ? 1 : 0}"
+  load_balancer_arn = "${aws_lb.default.arn}"
+
+  port            = "${var.prod_port}"
+  protocol        = "HTTP"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.blue.arn}"
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener" "test" {
+  count             = "${var.blue_green_enabled == "true" ? 1 : 0}"
+  load_balancer_arn = "${aws_lb.default.arn}"
+
+  port            = "${var.test_port}"
+  protocol        = "HTTP"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.green.arn}"
+    type             = "forward"
+  }
+}

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -59,6 +59,8 @@
 | default_target_group_arn | The default target group ARN |
 | http_listener_arn | The ARN of the HTTP listener |
 | https_listener_arn | The ARN of the HTTPS listener |
+| prod_listener_arn | The ARN of the production listener in Blue/Green |
+| test_listener_arn | The ARN of the test listener in Blue/Green |
 | listener_arns | A list of all the listener ARNs |
 | security_group_id | The security group ID of the ALB |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -6,6 +6,7 @@
 | access_logs_enabled | A boolean flag to enable/disable access_logs | string | `true` | no |
 | access_logs_prefix | The S3 bucket prefix | string | `` | no |
 | access_logs_region | The region for the access_logs S3 bucket | string | `us-east-1` | no |
+| access_logs_bucket_name | Bucket name (not recommended, legacy support only.) | string | `` | no |
 | attributes | Additional attributes, e.g. `1` | list | `<list>` | no |
 | certificate_arn | The ARN of the default SSL certificate for HTTPS listener | string | `` | no |
 | cross_zone_load_balancing_enabled | A boolean flag to enable/disable cross zone load balancing | string | `true` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -27,6 +27,13 @@
 | https_ingress_cidr_blocks | List of CIDR blocks to allow in HTTPS security group | list | `<list>` | no |
 | https_ingress_prefix_list_ids | List of prefix list IDs for allowing access to HTTPS ingress security group | list | `<list>` | no |
 | https_port | The port for the HTTPS listener | string | `443` | no |
+| blue_green_enabled | A boolean flag to enable/disable Blue/Green listeners | string | `false` | no |
+| prod_ingress_cidr_blocks | List of CIDR blocks to allow in production security group | list | `<list>` | no |
+| prod_ingress_prefix_list_ids | List of prefix list IDs for allowing access to production ingress security group | list | `<list>` | no |
+| prod_port | The port for the production listener | string | `80` | no |
+| test_ingress_cidr_blocks | List of CIDR blocks to allow in test security group | list | `<list>` | no |
+| test_ingress_prefix_list_ids | List of prefix list IDs for allowing access to test ingress security group | list | `<list>` | no |
+| test_port | The port for the test listener | string | `8080` | no |
 | idle_timeout | The time in seconds that the connection is allowed to be idle | string | `60` | no |
 | internal | A boolean flag to determine whether the ALB should be internal | string | `false` | no |
 | ip_address_type | The type of IP addresses used by the subnets for your load balancer. The possible values are `ipv4` and `dualstack`. | string | `ipv4` | no |

--- a/main.tf
+++ b/main.tf
@@ -46,6 +46,28 @@ resource "aws_security_group_rule" "https_ingress" {
   security_group_id = "${aws_security_group.default.id}"
 }
 
+resource "aws_security_group_rule" "prod_ingress" {
+  count             = "${var.blue_green_enabled == "true" ? 1 : 0}"
+  type              = "ingress"
+  from_port         = "${var.prod_port}"
+  to_port           = "${var.prod_port}"
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.prod_ingress_cidr_blocks}"]
+  prefix_list_ids   = ["${var.prod_ingress_prefix_list_ids}"]
+  security_group_id = "${aws_security_group.default.id}"
+}
+
+resource "aws_security_group_rule" "test_ingress" {
+  count             = "${var.blue_green_enabled == "true" ? 1 : 0}"
+  type              = "ingress"
+  from_port         = "${var.test_port}"
+  to_port           = "${var.test_port}"
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.test_ingress_cidr_blocks}"]
+  prefix_list_ids   = ["${var.test_ingress_prefix_list_ids}"]
+  security_group_id = "${aws_security_group.default.id}"
+}
+
 module "access_logs" {
   source     = "git::https://github.com/cloudposse/terraform-aws-lb-s3-bucket.git?ref=tags/0.1.0"
   attributes = "${var.attributes}"
@@ -87,8 +109,74 @@ module "default_target_group_label" {
   tags       = "${var.tags}"
 }
 
+module "blue_target_group_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.1.6"
+  attributes = "${concat(var.attributes, list("blue"))}"
+  delimiter  = "${var.delimiter}"
+  name       = "${var.name}"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  tags       = "${var.tags}"
+}
+
+module "green_target_group_label" {
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.1.6"
+  attributes = "${concat(var.attributes, list("green"))}"
+  delimiter  = "${var.delimiter}"
+  name       = "${var.name}"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  tags       = "${var.tags}"
+}
+
 resource "aws_lb_target_group" "default" {
   name                 = "${module.default_target_group_label.id}"
+  port                 = "80"
+  protocol             = "HTTP"
+  vpc_id               = "${var.vpc_id}"
+  target_type          = "ip"
+  deregistration_delay = "${var.deregistration_delay}"
+
+  health_check {
+    path                = "${var.health_check_path}"
+    timeout             = "${var.health_check_timeout}"
+    healthy_threshold   = "${var.health_check_healthy_threshold}"
+    unhealthy_threshold = "${var.health_check_unhealthy_threshold}"
+    interval            = "${var.health_check_interval}"
+    matcher             = "${var.health_check_matcher}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_lb_target_group" "blue" {
+  count                = "${var.blue_green_enabled == "true" ? 1 : 0}"
+  name                 = "${module.blue_target_group_label.id}"
+  port                 = "80"
+  protocol             = "HTTP"
+  vpc_id               = "${var.vpc_id}"
+  target_type          = "ip"
+  deregistration_delay = "${var.deregistration_delay}"
+
+  health_check {
+    path                = "${var.health_check_path}"
+    timeout             = "${var.health_check_timeout}"
+    healthy_threshold   = "${var.health_check_healthy_threshold}"
+    unhealthy_threshold = "${var.health_check_unhealthy_threshold}"
+    interval            = "${var.health_check_interval}"
+    matcher             = "${var.health_check_matcher}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_lb_target_group" "green" {
+  count                = "${var.blue_green_enabled == "true" ? 1 : 0}"
+  name                 = "${module.green_target_group_label.id}"
   port                 = "80"
   protocol             = "HTTP"
   vpc_id               = "${var.vpc_id}"
@@ -132,6 +220,32 @@ resource "aws_lb_listener" "https" {
 
   default_action {
     target_group_arn = "${aws_lb_target_group.default.arn}"
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener" "prod" {
+  count             = "${var.blue_green_enabled == "true" ? 1 : 0}"
+  load_balancer_arn = "${aws_lb.default.arn}"
+
+  port            = "${var.prod_port}"
+  protocol        = "HTTP"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.blue.arn}"
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener" "test" {
+  count             = "${var.blue_green_enabled == "true" ? 1 : 0}"
+  load_balancer_arn = "${aws_lb.default.arn}"
+
+  port            = "${var.test_port}"
+  protocol        = "HTTP"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.green.arn}"
     type             = "forward"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ resource "aws_security_group_rule" "https_ingress" {
 }
 
 module "access_logs" {
-  source        = "git::https://github.com/GMADLA/terraform-aws-lb-s3-bucket.git?ref=tags/0.1.5-dev.3"
+  source        = "git::https://github.com/GMADLA/terraform-aws-lb-s3-bucket.git?ref=tags/0.1.5-dev.4"
   attributes    = "${var.attributes}"
   delimiter     = "${var.delimiter}"
   name          = "${var.name}"

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ resource "aws_security_group_rule" "https_ingress" {
 }
 
 module "access_logs" {
-  source        = "git::https://github.com/GMADLA/terraform-aws-lb-s3-bucket.git?ref=tags/0.1.5-dev.2"
+  source        = "git::https://github.com/GMADLA/terraform-aws-lb-s3-bucket.git?ref=tags/0.1.5-dev.3"
   attributes    = "${var.attributes}"
   delimiter     = "${var.delimiter}"
   name          = "${var.name}"
@@ -72,7 +72,7 @@ resource "aws_lb" "default" {
   enable_deletion_protection       = "${var.deletion_protection_enabled}"
 
   access_logs {
-    bucket  = "${module.access_logs.bucket_id}"
+    bucket  = "${var.access_logs_bucket_name == "" ? module.access_logs.bucket_id : var.access_logs_bucket_name}"
     prefix  = "${var.access_logs_prefix}"
     enabled = "${var.access_logs_enabled}"
   }

--- a/main.tf
+++ b/main.tf
@@ -69,14 +69,15 @@ resource "aws_security_group_rule" "test_ingress" {
 }
 
 module "access_logs" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-lb-s3-bucket.git?ref=tags/0.1.0"
-  attributes = "${var.attributes}"
-  delimiter  = "${var.delimiter}"
-  name       = "${var.name}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  tags       = "${var.tags}"
-  region     = "${var.access_logs_region}"
+  source        = "git::https://github.com/GMADLA/terraform-aws-lb-s3-bucket.git?ref=tags/0.1.0"
+  attributes    = "${var.attributes}"
+  delimiter     = "${var.delimiter}"
+  name          = "${var.name}"
+  namespace     = "${var.namespace}"
+  stage         = "${var.stage}"
+  tags          = "${var.tags}"
+  region        = "${var.access_logs_region}"
+  legacy_bucket = "${var.access_logs_bucket_name == "" ? "" : var.access_logs_bucket_name}"
 }
 
 resource "aws_lb" "default" {

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ resource "aws_security_group_rule" "https_ingress" {
 }
 
 module "access_logs" {
-  source        = "git::https://github.com/GMADLA/terraform-aws-lb-s3-bucket.git?ref=tags/0.1.5-dev.1"
+  source        = "git::https://github.com/GMADLA/terraform-aws-lb-s3-bucket.git?ref=tags/0.1.5-dev.2"
   attributes    = "${var.attributes}"
   delimiter     = "${var.delimiter}"
   name          = "${var.name}"

--- a/main.tf
+++ b/main.tf
@@ -46,28 +46,6 @@ resource "aws_security_group_rule" "https_ingress" {
   security_group_id = "${aws_security_group.default.id}"
 }
 
-resource "aws_security_group_rule" "prod_ingress" {
-  count             = "${var.blue_green_enabled == "true" ? 1 : 0}"
-  type              = "ingress"
-  from_port         = "${var.prod_port}"
-  to_port           = "${var.prod_port}"
-  protocol          = "tcp"
-  cidr_blocks       = ["${var.prod_ingress_cidr_blocks}"]
-  prefix_list_ids   = ["${var.prod_ingress_prefix_list_ids}"]
-  security_group_id = "${aws_security_group.default.id}"
-}
-
-resource "aws_security_group_rule" "test_ingress" {
-  count             = "${var.blue_green_enabled == "true" ? 1 : 0}"
-  type              = "ingress"
-  from_port         = "${var.test_port}"
-  to_port           = "${var.test_port}"
-  protocol          = "tcp"
-  cidr_blocks       = ["${var.test_ingress_cidr_blocks}"]
-  prefix_list_ids   = ["${var.test_ingress_prefix_list_ids}"]
-  security_group_id = "${aws_security_group.default.id}"
-}
-
 module "access_logs" {
   source        = "git::https://github.com/GMADLA/terraform-aws-lb-s3-bucket.git?ref=tags/0.1.5-dev.1"
   attributes    = "${var.attributes}"
@@ -110,74 +88,8 @@ module "default_target_group_label" {
   tags       = "${var.tags}"
 }
 
-module "blue_target_group_label" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.1.6"
-  attributes = "${concat(var.attributes, list("blue"))}"
-  delimiter  = "${var.delimiter}"
-  name       = "${var.name}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  tags       = "${var.tags}"
-}
-
-module "green_target_group_label" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.1.6"
-  attributes = "${concat(var.attributes, list("green"))}"
-  delimiter  = "${var.delimiter}"
-  name       = "${var.name}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  tags       = "${var.tags}"
-}
-
 resource "aws_lb_target_group" "default" {
   name                 = "${module.default_target_group_label.id}"
-  port                 = "80"
-  protocol             = "HTTP"
-  vpc_id               = "${var.vpc_id}"
-  target_type          = "ip"
-  deregistration_delay = "${var.deregistration_delay}"
-
-  health_check {
-    path                = "${var.health_check_path}"
-    timeout             = "${var.health_check_timeout}"
-    healthy_threshold   = "${var.health_check_healthy_threshold}"
-    unhealthy_threshold = "${var.health_check_unhealthy_threshold}"
-    interval            = "${var.health_check_interval}"
-    matcher             = "${var.health_check_matcher}"
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_lb_target_group" "blue" {
-  count                = "${var.blue_green_enabled == "true" ? 1 : 0}"
-  name                 = "${module.blue_target_group_label.id}"
-  port                 = "80"
-  protocol             = "HTTP"
-  vpc_id               = "${var.vpc_id}"
-  target_type          = "ip"
-  deregistration_delay = "${var.deregistration_delay}"
-
-  health_check {
-    path                = "${var.health_check_path}"
-    timeout             = "${var.health_check_timeout}"
-    healthy_threshold   = "${var.health_check_healthy_threshold}"
-    unhealthy_threshold = "${var.health_check_unhealthy_threshold}"
-    interval            = "${var.health_check_interval}"
-    matcher             = "${var.health_check_matcher}"
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_lb_target_group" "green" {
-  count                = "${var.blue_green_enabled == "true" ? 1 : 0}"
-  name                 = "${module.green_target_group_label.id}"
   port                 = "80"
   protocol             = "HTTP"
   vpc_id               = "${var.vpc_id}"
@@ -221,32 +133,6 @@ resource "aws_lb_listener" "https" {
 
   default_action {
     target_group_arn = "${aws_lb_target_group.default.arn}"
-    type             = "forward"
-  }
-}
-
-resource "aws_lb_listener" "prod" {
-  count             = "${var.blue_green_enabled == "true" ? 1 : 0}"
-  load_balancer_arn = "${aws_lb.default.arn}"
-
-  port            = "${var.prod_port}"
-  protocol        = "HTTP"
-
-  default_action {
-    target_group_arn = "${aws_lb_target_group.blue.arn}"
-    type             = "forward"
-  }
-}
-
-resource "aws_lb_listener" "test" {
-  count             = "${var.blue_green_enabled == "true" ? 1 : 0}"
-  load_balancer_arn = "${aws_lb.default.arn}"
-
-  port            = "${var.test_port}"
-  protocol        = "HTTP"
-
-  default_action {
-    target_group_arn = "${aws_lb_target_group.green.arn}"
     type             = "forward"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ resource "aws_security_group_rule" "https_ingress" {
 }
 
 module "access_logs" {
-  source        = "git::https://github.com/GMADLA/terraform-aws-lb-s3-bucket.git?ref=tags/0.1.5-dev.4"
+  source        = "git::https://github.com/GMADLA/terraform-aws-lb-s3-bucket.git?ref=tags/0.1.5"
   attributes    = "${var.attributes}"
   delimiter     = "${var.delimiter}"
   name          = "${var.name}"

--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ resource "aws_security_group_rule" "test_ingress" {
 }
 
 module "access_logs" {
-  source        = "git::https://github.com/GMADLA/terraform-aws-lb-s3-bucket.git?ref=tags/0.1.0"
+  source        = "git::https://github.com/GMADLA/terraform-aws-lb-s3-bucket.git?ref=tags/0.1.5-dev.1"
   attributes    = "${var.attributes}"
   delimiter     = "${var.delimiter}"
   name          = "${var.name}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -35,12 +35,12 @@ output "default_target_group_arn" {
 
 output "blue_target_group_arn" {
   description = "The blue target group ARN for Blue/Green"
-  value       = "${aws_lb_target_group.blue.arn}"
+  value       = "${join("", aws_lb_target_group.blue.*.arn)}"
 }
 
 output "green_target_group_arn" {
   description = "The green target group ARN for Blue/Green"
-  value       = "${aws_lb_target_group.green.arn}"
+  value       = "${join("", aws_lb_target_group.green.*.arn)}"
 }
 
 output "http_listener_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -33,6 +33,16 @@ output "default_target_group_arn" {
   value       = "${aws_lb_target_group.default.arn}"
 }
 
+output "blue_target_group_arn" {
+  description = "The blue target group ARN for Blue/Green"
+  value       = "${aws_lb_target_group.blue.arn}"
+}
+
+output "green_target_group_arn" {
+  description = "The green target group ARN for Blue/Green"
+  value       = "${aws_lb_target_group.green.arn}"
+}
+
 output "http_listener_arn" {
   description = "The ARN of the HTTP listener"
   value       = "${join("", aws_lb_listener.http.*.arn)}"
@@ -41,6 +51,16 @@ output "http_listener_arn" {
 output "https_listener_arn" {
   description = "The ARN of the HTTPS listener"
   value       = "${join("", aws_lb_listener.https.*.arn)}"
+}
+
+output "prod_listener_arn" {
+  description = "The ARN of the production listener for Blue/Green"
+  value       = "${join("", aws_lb_listener.prod.*.arn)}"
+}
+
+output "test_listener_arn" {
+  description = "The ARN of the test listener for Blue/Green"
+  value       = "${join("", aws_lb_listener.test.*.arn)}"
 }
 
 output "listener_arns" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -33,16 +33,6 @@ output "default_target_group_arn" {
   value       = "${aws_lb_target_group.default.arn}"
 }
 
-output "blue_target_group_arn" {
-  description = "The blue target group ARN for Blue/Green"
-  value       = "${join("", aws_lb_target_group.blue.*.arn)}"
-}
-
-output "green_target_group_arn" {
-  description = "The green target group ARN for Blue/Green"
-  value       = "${join("", aws_lb_target_group.green.*.arn)}"
-}
-
 output "http_listener_arn" {
   description = "The ARN of the HTTP listener"
   value       = "${join("", aws_lb_listener.http.*.arn)}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -35,12 +35,12 @@ output "default_target_group_arn" {
 
 output "blue_target_group_arn" {
   description = "The blue target group ARN for Blue/Green"
-  value       = "${aws_lb_target_group.blue.arn}"
+  value       = "${aws_lb_target_group.blue.*.arn}"
 }
 
 output "green_target_group_arn" {
   description = "The green target group ARN for Blue/Green"
-  value       = "${aws_lb_target_group.green.arn}"
+  value       = "${aws_lb_target_group.green.*.arn}"
 }
 
 output "http_listener_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -35,12 +35,12 @@ output "default_target_group_arn" {
 
 output "blue_target_group_arn" {
   description = "The blue target group ARN for Blue/Green"
-  value       = "${aws_lb_target_group.blue.*.arn}"
+  value       = "${aws_lb_target_group.blue.arn}"
 }
 
 output "green_target_group_arn" {
   description = "The green target group ARN for Blue/Green"
-  value       = "${aws_lb_target_group.green.*.arn}"
+  value       = "${aws_lb_target_group.green.arn}"
 }
 
 output "http_listener_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -107,6 +107,48 @@ variable "https_ingress_prefix_list_ids" {
   description = "List of prefix list IDs for allowing access to HTTPS ingress security group"
 }
 
+variable "prod_port" {
+  type        = "string"
+  default     = "80"
+  description = "The port for the production listener"
+}
+
+variable "blue_green_enabled" {
+  type        = "string"
+  default     = "false"
+  description = "A boolean flag to create Blue/Green target groups and production/test listeners"
+}
+
+variable "prod_ingress_cidr_blocks" {
+  type        = "list"
+  default     = ["0.0.0.0/0"]
+  description = "List of CIDR blocks to allow in production security group"
+}
+
+variable "prod_ingress_prefix_list_ids" {
+  type        = "list"
+  default     = []
+  description = "List of prefix list IDs for allowing access to production ingress security group"
+}
+
+variable "test_port" {
+  type        = "string"
+  default     = "8080"
+  description = "The port for the test listener"
+}
+
+variable "test_ingress_cidr_blocks" {
+  type        = "list"
+  default     = ["0.0.0.0/0"]
+  description = "List of CIDR blocks to allow in test security group"
+}
+
+variable "test_ingress_prefix_list_ids" {
+  type        = "list"
+  default     = []
+  description = "List of prefix list IDs for allowing access to test ingress security group"
+}
+
 variable "access_logs_prefix" {
   type        = "string"
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -167,6 +167,12 @@ variable "access_logs_region" {
   description = "The region for the access_logs S3 bucket"
 }
 
+variable "access_logs_bucket_name" {
+  type        = "string"
+  default     = ""
+  description = "The bucket for the access_logs S3 bucket, (not recommended, legacy support only)"
+}
+
 variable "cross_zone_load_balancing_enabled" {
   type        = "string"
   default     = "true"


### PR DESCRIPTION
- Updates the s3 bucker module to allow the use of a legacy bucket.
- Allows a user to create prod/test ingress for B/G deployment
- Creates up to 4 listeners allowing a migration to from our current http/https to prod/https/test