### PR TITLE
We really only need the adition of a test ingress.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,7 @@ Available targets:
 | https_ingress_cidr_blocks | List of CIDR blocks to allow in HTTPS security group | list | `<list>` | no |
 | https_ingress_prefix_list_ids | List of prefix list IDs for allowing access to HTTPS ingress security group | list | `<list>` | no |
 | https_port | The port for the HTTPS listener | string | `443` | no |
-| blue_green_enabled | A boolean flag to enable/disable BLUE/Green target groups and production/test listeners | string | `false` | no |
-| prod_ingress_cidr_blocks | List of CIDR blocks to allow in production security group | list | `<list>` | no |
-| prod_ingress_prefix_list_ids | List of prefix list IDs for allowing access to production ingress security group | list | `<list>` | no |
-| prod_port | The port for the production listener | string | `80` | no |
+| test_enabled | A boolean flag to enable/disable BLUE/Green target groups and production/test listeners | string | `false` | no |
 | test_ingress_cidr_blocks | List of CIDR blocks to allow in test security group | list | `<list>` | no |
 | test_ingress_prefix_list_ids | List of prefix list IDs for allowing access to test ingress security group | list | `<list>` | no |
 | test_port | The port for the test listener | string | `8080` | no |
@@ -118,7 +115,6 @@ Available targets:
 | default_target_group_arn | The default target group ARN |
 | http_listener_arn | The ARN of the HTTP listener |
 | https_listener_arn | The ARN of the HTTPS listener |
-| prod_listener_arn | The ARN of the production listener in Blue/Green |
 | test_listener_arn | The ARN of the test listener in Blue/Green |
 | listener_arns | A list of all the listener ARNs |
 | security_group_id | The security group ID of the ALB |

--- a/bg.tf
+++ b/bg.tf
@@ -1,16 +1,5 @@
-resource "aws_security_group_rule" "prod_ingress" {
-  count             = "${var.blue_green_enabled == "true" ? 1 : 0}"
-  type              = "ingress"
-  from_port         = "${var.prod_port}"
-  to_port           = "${var.prod_port}"
-  protocol          = "tcp"
-  cidr_blocks       = ["${var.prod_ingress_cidr_blocks}"]
-  prefix_list_ids   = ["${var.prod_ingress_prefix_list_ids}"]
-  security_group_id = "${aws_security_group.default.id}"
-}
-
 resource "aws_security_group_rule" "test_ingress" {
-  count             = "${var.blue_green_enabled == "true" ? 1 : 0}"
+  count             = "${var.test_enabled == "true" ? 1 : 0}"
   type              = "ingress"
   from_port         = "${var.test_port}"
   to_port           = "${var.test_port}"
@@ -20,21 +9,8 @@ resource "aws_security_group_rule" "test_ingress" {
   security_group_id = "${aws_security_group.default.id}"
 }
 
-resource "aws_lb_listener" "prod" {
-  count             = "${var.blue_green_enabled == "true" ? 1 : 0}"
-  load_balancer_arn = "${aws_lb.default.arn}"
-
-  port            = "${var.prod_port}"
-  protocol        = "HTTP"
-
-  default_action {
-    target_group_arn = "${aws_lb_target_group.default.arn}"
-    type             = "forward"
-  }
-}
-
 resource "aws_lb_listener" "test" {
-  count             = "${var.blue_green_enabled == "true" ? 1 : 0}"
+  count             = "${var.test_enabled == "true" ? 1 : 0}"
   load_balancer_arn = "${aws_lb.default.arn}"
 
   port            = "${var.test_port}"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -28,10 +28,7 @@
 | https_ingress_cidr_blocks | List of CIDR blocks to allow in HTTPS security group | list | `<list>` | no |
 | https_ingress_prefix_list_ids | List of prefix list IDs for allowing access to HTTPS ingress security group | list | `<list>` | no |
 | https_port | The port for the HTTPS listener | string | `443` | no |
-| blue_green_enabled | A boolean flag to enable/disable Blue/Green listeners | string | `false` | no |
-| prod_ingress_cidr_blocks | List of CIDR blocks to allow in production security group | list | `<list>` | no |
-| prod_ingress_prefix_list_ids | List of prefix list IDs for allowing access to production ingress security group | list | `<list>` | no |
-| prod_port | The port for the production listener | string | `80` | no |
+| test_enabled | A boolean flag to enable/disable Blue/Green listeners | string | `false` | no |
 | test_ingress_cidr_blocks | List of CIDR blocks to allow in test security group | list | `<list>` | no |
 | test_ingress_prefix_list_ids | List of prefix list IDs for allowing access to test ingress security group | list | `<list>` | no |
 | test_port | The port for the test listener | string | `8080` | no |
@@ -59,7 +56,6 @@
 | default_target_group_arn | The default target group ARN |
 | http_listener_arn | The ARN of the HTTP listener |
 | https_listener_arn | The ARN of the HTTPS listener |
-| prod_listener_arn | The ARN of the production listener in Blue/Green |
 | test_listener_arn | The ARN of the test listener in Blue/Green |
 | listener_arns | A list of all the listener ARNs |
 | security_group_id | The security group ID of the ALB |

--- a/outputs.tf
+++ b/outputs.tf
@@ -43,11 +43,6 @@ output "https_listener_arn" {
   value       = "${join("", aws_lb_listener.https.*.arn)}"
 }
 
-output "prod_listener_arn" {
-  description = "The ARN of the production listener for Blue/Green"
-  value       = "${join("", aws_lb_listener.prod.*.arn)}"
-}
-
 output "test_listener_arn" {
   description = "The ARN of the test listener for Blue/Green"
   value       = "${join("", aws_lb_listener.test.*.arn)}"

--- a/variables.tf
+++ b/variables.tf
@@ -107,28 +107,10 @@ variable "https_ingress_prefix_list_ids" {
   description = "List of prefix list IDs for allowing access to HTTPS ingress security group"
 }
 
-variable "prod_port" {
-  type        = "string"
-  default     = "80"
-  description = "The port for the production listener"
-}
-
-variable "blue_green_enabled" {
+variable "test_enabled" {
   type        = "string"
   default     = "false"
   description = "A boolean flag to create Blue/Green target groups and production/test listeners"
-}
-
-variable "prod_ingress_cidr_blocks" {
-  type        = "list"
-  default     = ["0.0.0.0/0"]
-  description = "List of CIDR blocks to allow in production security group"
-}
-
-variable "prod_ingress_prefix_list_ids" {
-  type        = "list"
-  default     = []
-  description = "List of prefix list IDs for allowing access to production ingress security group"
 }
 
 variable "test_port" {


### PR DESCRIPTION
- After testing the listener migration from port 81 -> 80 I realized we really only need the addition of a test ingress. The new blue/green ECS services may use the existing port 80 with differing priority. This will reduce listener port conflicts and reduce possible downtime in the from switching ports.