### PR TITLE
Allows to use and existing bucket instead of creating one.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ Available targets:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| access\_logs\_bucket\_id | The name of an existing bucket to use for access logs | `string` | `""` | no |
+| access\_logs\_create | A boolean flag to create access logs bucket | `bool` | `true` | no |
 | access\_logs\_enabled | A boolean flag to enable/disable access\_logs | `bool` | `true` | no |
 | access\_logs\_prefix | The S3 log bucket prefix | `string` | `""` | no |
 | additional\_certs | A list of additonal certs to add to the https listerner | `list(string)` | `[]` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -19,6 +19,8 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| access\_logs\_bucket\_id | The name of an existing bucket to use for access logs | `string` | `""` | no |
+| access\_logs\_create | A boolean flag to create access logs bucket | `bool` | `true` | no |
 | access\_logs\_enabled | A boolean flag to enable/disable access\_logs | `bool` | `true` | no |
 | access\_logs\_prefix | The S3 log bucket prefix | `string` | `""` | no |
 | additional\_certs | A list of additonal certs to add to the https listerner | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "aws_security_group_rule" "https_ingress" {
 module "access_logs" {
   source                             = "cloudposse/lb-s3-bucket/aws"
   version                            = "0.9.0"
-  enabled                            = module.this.enabled && var.access_logs_enabled
+  enabled                            = module.this.enabled && var.access_logs_create
   name                               = module.this.name
   namespace                          = module.this.namespace
   stage                              = module.this.stage
@@ -78,7 +78,7 @@ resource "aws_lb" "default" {
   enable_deletion_protection       = var.deletion_protection_enabled
 
   access_logs {
-    bucket  = module.access_logs.bucket_id
+    bucket  = var.access_logs_create ? module.access_logs.bucket_id : var.access_logs_bucket_id
     prefix  = var.access_logs_prefix
     enabled = var.access_logs_enabled
   }

--- a/variables.tf
+++ b/variables.tf
@@ -98,6 +98,18 @@ variable "access_logs_enabled" {
   description = "A boolean flag to enable/disable access_logs"
 }
 
+variable "access_logs_create" {
+  type        = bool
+  default     = true
+  description = "A boolean flag to create access logs bucket"
+}
+
+variable "access_logs_bucket_id" {
+  type        = string
+  default     = ""
+  description = "The name of an existing bucket to use for access logs"
+}
+
 variable "cross_zone_load_balancing_enabled" {
   type        = bool
   default     = true


### PR DESCRIPTION
## what
* Added a variable `access_logs_create` to determine creation of an s3 bucket for logs.
* Added a variable `access_logs_bucket_id` to allow input of an existing s3 bucket.

## why
* We may store access logs in an existing bucket not conforming to the existing label conventions 
